### PR TITLE
Fix the CONFIG_DEFAULT_MMAP_MIN_ADDR recommendation for arm64

### DIFF
--- a/Recommended_Settings.md
+++ b/Recommended_Settings.md
@@ -325,8 +325,8 @@ CONFIG_CFI_CLANG=y
 ## arm64
 
 ```
-# Disallow allocating the first 32k of memory (cannot be 64k due to ARM loader).
-CONFIG_DEFAULT_MMAP_MIN_ADDR=32768
+# Disallow allocating the first 64k of memory.
+CONFIG_DEFAULT_MMAP_MIN_ADDR=65536
 
 # Randomize position of kernel (requires UEFI RNG or bootloader support for /chosen/kaslr-seed DT property).
 CONFIG_RANDOMIZE_BASE=y


### PR DESCRIPTION
Quote from kernel sources:
```
For most arm64, ppc64 and x86 users with lots of address space
a value of 65536 is reasonable and should cause no problems.
On arm and other archs it should not be higher than 32768.
```
https://elixir.bootlin.com/linux/v6.12.1/source/mm/Kconfig#L743